### PR TITLE
ci: manage Go modules with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,25 @@
 version: 2
 updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
+  - package-ecosystem: "gomod"
+    directories:
+      - "/"
+      - "/**"
     schedule:
       interval: "daily"
     open-pull-requests-limit: 10
     commit-message:
-      prefix: "chore: update version"
-    allow:
-      - dependency-name: github.com/jackc/pgx/v5
-      - dependency-name: github.com/lib/pq
+      prefix: "chore"
+    groups:
+      go-deps:
+        patterns: ["*"]
+        update-types: ["minor", "patch"]
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "chore"
+    groups:
+      gha:
+        patterns: ["*"]


### PR DESCRIPTION
Adds daily Dependabot Go-module updates across all module directories (root + nested via `directories: ["/", "/**"]`). Minor/patch grouped into one PR; majors arrive individually.