### PR TITLE
feat: bump go-pq-cdc v1.10.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/Trendyol/go-pq-cdc-elasticsearch
 go 1.25.0
 
 require (
-	github.com/Trendyol/go-pq-cdc v1.10.11
+	github.com/Trendyol/go-pq-cdc v1.10.12
 	github.com/docker/go-connections v0.5.0
 	github.com/elastic/go-elasticsearch/v7 v7.17.10
 	github.com/go-playground/errors v3.3.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOEl
 github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
-github.com/Trendyol/go-pq-cdc v1.10.11 h1:z8qr92Kysy2C55Uita8hhL3MVCXEhE8/YwZ+VZQwp/E=
-github.com/Trendyol/go-pq-cdc v1.10.11/go.mod h1:a0Z9SANfTzs/5tQyBq2cUCkzyW2rgDrdpQuegKKSx34=
+github.com/Trendyol/go-pq-cdc v1.10.12 h1:N/lbUYfJWKWvjCl91SzKHJjDQDuFKt9TzvLqN9tqlus=
+github.com/Trendyol/go-pq-cdc v1.10.12/go.mod h1:a0Z9SANfTzs/5tQyBq2cUCkzyW2rgDrdpQuegKKSx34=
 github.com/andybalholm/brotli v1.1.0 h1:eLKJA0d02Lf0mVpIDgYnqXcUn0GqVmEFny3VuID1U3M=
 github.com/andybalholm/brotli v1.1.0/go.mod h1:sms7XGricyQI9K10gOSf56VKKWS4oLer58Q+mhRPtnY=
 github.com/avast/retry-go/v4 v4.6.0 h1:K9xNA+KeB8HHc2aWFuLb25Offp+0iVRXEvFx8IinRJA=


### PR DESCRIPTION
Bumps `github.com/Trendyol/go-pq-cdc` from v1.10.11 to v1.10.12.