### PR TITLE
fix: separate readyCh and closedCh connector lifecycle

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -36,6 +36,8 @@ type connector struct {
 	cfg             *config.Config
 	esClient        *es.Client
 	readyCh         chan struct{}
+	closedCh        chan struct{}
+	closeOnce       sync.Once
 	partitionCache  sync.Map
 	metrics         []prometheus.Collector
 }
@@ -44,9 +46,10 @@ func NewConnector(ctx context.Context, cfg config.Config, handler Handler, optio
 	cfg.SetDefault()
 
 	esConnector := &connector{
-		cfg:     &cfg,
-		handler: handler,
-		readyCh: make(chan struct{}, 1),
+		cfg:      &cfg,
+		handler:  handler,
+		readyCh:  make(chan struct{}, 1),
+		closedCh: make(chan struct{}),
 	}
 
 	Options(options).Apply(esConnector)
@@ -87,7 +90,7 @@ func (c *connector) Start(ctx context.Context) {
 		c.bulk.StartBulk()
 
 		// Signal ready immediately since there's no CDC to wait for
-		c.readyCh <- struct{}{}
+		c.signalReady()
 
 		// Start CDC synchronously - it will execute snapshot and return
 		c.cdc.Start(ctx)
@@ -103,7 +106,7 @@ func (c *connector) Start(ctx context.Context) {
 		}
 		logger.Info("bulk process started")
 		c.bulk.StartBulk()
-		c.readyCh <- struct{}{}
+		c.signalReady()
 	}()
 	c.cdc.Start(ctx)
 }
@@ -112,18 +115,28 @@ func (c *connector) WaitUntilReady(ctx context.Context) error {
 	select {
 	case <-c.readyCh:
 		return nil
+	case <-c.closedCh:
+		return errors.New("connector closed")
 	case <-ctx.Done():
 		return ctx.Err()
 	}
 }
 
 func (c *connector) Close() {
-	if !isClosed(c.readyCh) {
-		close(c.readyCh)
-	}
+	c.closeOnce.Do(func() {
+		close(c.closedCh)
 
-	c.cdc.Close()
-	c.bulk.Close()
+		c.cdc.Close()
+		c.bulk.Close()
+	})
+}
+
+func (c *connector) signalReady() {
+	select {
+	case <-c.closedCh:
+		return
+	case c.readyCh <- struct{}{}:
+	}
 }
 
 func (c *connector) listener(ctx *replication.ListenerContext) {
@@ -246,14 +259,4 @@ func (c *connector) findParentTable(tableNamespace, tableName string) string {
 	}
 
 	return ""
-}
-
-func isClosed[T any](ch <-chan T) bool {
-	select {
-	case <-ch:
-		return true
-	default:
-	}
-
-	return false
 }

--- a/connector.go
+++ b/connector.go
@@ -37,9 +37,9 @@ type connector struct {
 	esClient        *es.Client
 	readyCh         chan struct{}
 	closedCh        chan struct{}
-	closeOnce       sync.Once
 	partitionCache  sync.Map
 	metrics         []prometheus.Collector
+	closeOnce       sync.Once
 }
 
 func NewConnector(ctx context.Context, cfg config.Config, handler Handler, options ...Option) (Connector, error) {
@@ -99,19 +99,42 @@ func (c *connector) Start(ctx context.Context) {
 	}
 
 	// Normal CDC mode: async flow
-	go func() {
-		logger.Info("waiting for connector start...")
-		if err := c.cdc.WaitUntilReady(ctx); err != nil {
-			panic(err)
+	go c.runUntilReady(ctx)
+	go c.runCDC(ctx)
+}
+
+func (c *connector) runUntilReady(ctx context.Context) {
+	logger.Info("waiting for connector start...")
+	if err := c.cdc.WaitUntilReady(ctx); err != nil {
+		if c.isClosed() {
+			return
 		}
-		logger.Info("bulk process started")
-		c.bulk.StartBulk()
-		c.signalReady()
+		panic(err)
+	}
+	if c.isClosed() {
+		return
+	}
+	logger.Info("bulk process started")
+	c.bulk.StartBulk()
+	c.signalReady()
+}
+
+func (c *connector) runCDC(ctx context.Context) {
+	defer func() {
+		if r := recover(); r != nil && !c.isClosed() {
+			panic(r)
+		}
 	}()
 	c.cdc.Start(ctx)
 }
 
 func (c *connector) WaitUntilReady(ctx context.Context) error {
+	select {
+	case <-c.closedCh:
+		return errors.New("connector closed")
+	default:
+	}
+
 	select {
 	case <-c.readyCh:
 		return nil
@@ -119,6 +142,15 @@ func (c *connector) WaitUntilReady(ctx context.Context) error {
 		return errors.New("connector closed")
 	case <-ctx.Done():
 		return ctx.Err()
+	}
+}
+
+func (c *connector) isClosed() bool {
+	select {
+	case <-c.closedCh:
+		return true
+	default:
+		return false
 	}
 }
 
@@ -132,6 +164,10 @@ func (c *connector) Close() {
 }
 
 func (c *connector) signalReady() {
+	if c.isClosed() {
+		return
+	}
+
 	select {
 	case <-c.closedCh:
 		return

--- a/connector_lifecycle_test.go
+++ b/connector_lifecycle_test.go
@@ -1,0 +1,74 @@
+package cdc
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWaitUntilReadyReturnsClosedWhenReadyPendingInBuffer(t *testing.T) {
+	c := &connector{
+		readyCh:  make(chan struct{}, 1),
+		closedCh: make(chan struct{}),
+	}
+
+	c.readyCh <- struct{}{}
+	close(c.closedCh)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	err := c.WaitUntilReady(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "connector closed")
+}
+
+func TestWaitUntilReadyReturnsReadyWhenNotClosed(t *testing.T) {
+	c := &connector{
+		readyCh:  make(chan struct{}, 1),
+		closedCh: make(chan struct{}),
+	}
+
+	c.readyCh <- struct{}{}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	require.NoError(t, c.WaitUntilReady(ctx))
+}
+
+func TestWaitUntilReadyReturnsClosedAfterClose(t *testing.T) {
+	c := &connector{
+		readyCh:  make(chan struct{}, 1),
+		closedCh: make(chan struct{}),
+	}
+
+	close(c.closedCh)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+
+	err := c.WaitUntilReady(ctx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "connector closed")
+}
+
+func TestIsClosedReturnsFalseForOpenConnector(t *testing.T) {
+	c := &connector{
+		closedCh: make(chan struct{}),
+	}
+
+	assert.False(t, c.isClosed())
+}
+
+func TestIsClosedReturnsTrueAfterClose(t *testing.T) {
+	c := &connector{
+		closedCh: make(chan struct{}),
+	}
+
+	close(c.closedCh)
+	assert.True(t, c.isClosed())
+}

--- a/integration_test/lifecycle_test.go
+++ b/integration_test/lifecycle_test.go
@@ -20,9 +20,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const (
+	lifecycleSlotName        = "cdc_slot_lifecycle"
+	lifecyclePublicationName = "cdc_publication_lifecycle"
+	lifecycleTableName       = "users_lifecycle"
+)
+
 func TestConnector_WaitUntilReadyAfterClose(t *testing.T) {
 	ctx := context.Background()
-	connector := newLifecycleConnector(ctx, t, "cdc_slot_lifecycle_closed", "cdc_publication_lifecycle_closed", "users_lifecycle_closed")
+	connector := newLifecycleConnector(ctx, t)
 
 	go connector.Start(ctx)
 
@@ -42,7 +48,7 @@ func TestConnector_WaitUntilReadyAfterClose(t *testing.T) {
 
 func TestConnector_CloseIsIdempotent(t *testing.T) {
 	ctx := context.Background()
-	connector := newLifecycleConnector(ctx, t, "cdc_slot_lifecycle_idempotent", "cdc_publication_lifecycle_idempotent", "users_lifecycle_idempotent")
+	connector := newLifecycleConnector(ctx, t)
 
 	go connector.Start(ctx)
 
@@ -58,7 +64,7 @@ func TestConnector_CloseIsIdempotent(t *testing.T) {
 
 func TestConnector_CloseBeforeWaitUntilReadyDoesNotHang(t *testing.T) {
 	ctx := context.Background()
-	connector := newLifecycleConnector(ctx, t, "cdc_slot_lifecycle_early_close", "cdc_publication_lifecycle_early_close", "users_lifecycle_early_close")
+	connector := newLifecycleConnector(ctx, t)
 
 	go connector.Start(ctx)
 
@@ -86,7 +92,7 @@ func waitForConnectorReady(ctx context.Context, t *testing.T, connector cdc.Conn
 	require.NoError(t, connector.WaitUntilReady(readyCtx))
 }
 
-func newLifecycleConnector(ctx context.Context, t *testing.T, slotName, publicationName, tableName string) cdc.Connector {
+func newLifecycleConnector(ctx context.Context, t *testing.T) cdc.Connector {
 	t.Helper()
 
 	db, err := sql.Open("postgres", fmt.Sprintf(
@@ -101,7 +107,7 @@ func newLifecycleConnector(ctx context.Context, t *testing.T, slotName, publicat
 			id SERIAL PRIMARY KEY,
 			name TEXT NOT NULL
 		)
-	`, tableName))
+	`, lifecycleTableName))
 	require.NoError(t, err)
 
 	postgresPort, err := strconv.Atoi(Infra.PostgresPort)
@@ -117,7 +123,7 @@ func newLifecycleConnector(ctx context.Context, t *testing.T, slotName, publicat
 			DebugMode: false,
 			Publication: publication.Config{
 				CreateIfNotExists: true,
-				Name:              publicationName,
+				Name:              lifecyclePublicationName,
 				Operations: publication.Operations{
 					publication.OperationInsert,
 					publication.OperationDelete,
@@ -125,14 +131,14 @@ func newLifecycleConnector(ctx context.Context, t *testing.T, slotName, publicat
 				},
 				Tables: publication.Tables{
 					publication.Table{
-						Name:            tableName,
+						Name:            lifecycleTableName,
 						ReplicaIdentity: publication.ReplicaIdentityFull,
 					},
 				},
 			},
 			Slot: slot.Config{
 				CreateIfNotExists:           true,
-				Name:                        slotName,
+				Name:                        lifecycleSlotName,
 				SlotActivityCheckerInterval: 3000,
 			},
 			Logger: cdcconfig.LoggerConfig{
@@ -141,7 +147,7 @@ func newLifecycleConnector(ctx context.Context, t *testing.T, slotName, publicat
 		},
 		Elasticsearch: config.Elasticsearch{
 			TableIndexMapping: map[string]string{
-				fmt.Sprintf("public.%s", tableName): fmt.Sprintf("%s.test", tableName),
+				fmt.Sprintf("public.%s", lifecycleTableName): fmt.Sprintf("%s.test", lifecycleTableName),
 			},
 			BatchTickerDuration:         time.Millisecond * 100,
 			BatchSizeLimit:              10,

--- a/integration_test/lifecycle_test.go
+++ b/integration_test/lifecycle_test.go
@@ -1,0 +1,155 @@
+package integration
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"testing"
+	"time"
+
+	cdc "github.com/Trendyol/go-pq-cdc-elasticsearch"
+	"github.com/Trendyol/go-pq-cdc-elasticsearch/config"
+	"github.com/Trendyol/go-pq-cdc-elasticsearch/elasticsearch"
+	cdcconfig "github.com/Trendyol/go-pq-cdc/config"
+	"github.com/Trendyol/go-pq-cdc/pq/publication"
+	"github.com/Trendyol/go-pq-cdc/pq/slot"
+	_ "github.com/lib/pq"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConnector_WaitUntilReadyAfterClose(t *testing.T) {
+	ctx := context.Background()
+	connector := newLifecycleConnector(t, ctx, "cdc_slot_lifecycle_closed", "cdc_publication_lifecycle_closed", "users_lifecycle_closed")
+
+	go connector.Start(ctx)
+
+	readyCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	require.NoError(t, connector.WaitUntilReady(readyCtx))
+
+	connector.Close()
+
+	afterCloseCtx, afterCloseCancel := context.WithTimeout(ctx, 2*time.Second)
+	defer afterCloseCancel()
+
+	err := connector.WaitUntilReady(afterCloseCtx)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "connector closed")
+}
+
+func TestConnector_CloseIsIdempotent(t *testing.T) {
+	ctx := context.Background()
+	connector := newLifecycleConnector(t, ctx, "cdc_slot_lifecycle_idempotent", "cdc_publication_lifecycle_idempotent", "users_lifecycle_idempotent")
+
+	go connector.Start(ctx)
+
+	readyCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	require.NoError(t, connector.WaitUntilReady(readyCtx))
+
+	require.NotPanics(t, func() {
+		connector.Close()
+		connector.Close()
+	})
+}
+
+func TestConnector_CloseBeforeWaitUntilReadyDoesNotHang(t *testing.T) {
+	ctx := context.Background()
+	connector := newLifecycleConnector(t, ctx, "cdc_slot_lifecycle_early_close", "cdc_publication_lifecycle_early_close", "users_lifecycle_early_close")
+
+	go connector.Start(ctx)
+
+	time.Sleep(100 * time.Millisecond)
+	connector.Close()
+
+	waitCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+	defer cancel()
+
+	started := time.Now()
+	err := connector.WaitUntilReady(waitCtx)
+	elapsed := time.Since(started)
+
+	assert.Less(t, elapsed, 3500*time.Millisecond, "WaitUntilReady must not hang after Close")
+	if err != nil {
+		assert.True(t,
+			err.Error() == "connector closed" || waitCtx.Err() != nil,
+			"unexpected error: %v", err,
+		)
+	}
+}
+
+func newLifecycleConnector(t *testing.T, ctx context.Context, slotName, publicationName, tableName string) cdc.Connector {
+	t.Helper()
+
+	db, err := sql.Open("postgres", fmt.Sprintf(
+		"postgres://cdc_user:cdc_pass@%s:%s/cdc_db?sslmode=disable",
+		Infra.PostgresHost, Infra.PostgresPort,
+	))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	_, err = db.Exec(fmt.Sprintf(`
+		CREATE TABLE IF NOT EXISTS %s (
+			id SERIAL PRIMARY KEY,
+			name TEXT NOT NULL
+		)
+	`, tableName))
+	require.NoError(t, err)
+
+	postgresPort, err := strconv.Atoi(Infra.PostgresPort)
+	require.NoError(t, err)
+
+	cfg := config.Config{
+		CDC: cdcconfig.Config{
+			Host:      Infra.PostgresHost,
+			Port:      postgresPort,
+			Username:  "cdc_user",
+			Password:  "cdc_pass",
+			Database:  "cdc_db",
+			DebugMode: false,
+			Publication: publication.Config{
+				CreateIfNotExists: true,
+				Name:              publicationName,
+				Operations: publication.Operations{
+					publication.OperationInsert,
+					publication.OperationDelete,
+					publication.OperationUpdate,
+				},
+				Tables: publication.Tables{
+					publication.Table{
+						Name:            tableName,
+						ReplicaIdentity: publication.ReplicaIdentityFull,
+					},
+				},
+			},
+			Slot: slot.Config{
+				CreateIfNotExists:           true,
+				Name:                        slotName,
+				SlotActivityCheckerInterval: 3000,
+			},
+			Logger: cdcconfig.LoggerConfig{
+				LogLevel: slog.LevelInfo,
+			},
+		},
+		Elasticsearch: config.Elasticsearch{
+			TableIndexMapping: map[string]string{
+				fmt.Sprintf("public.%s", tableName): fmt.Sprintf("%s.test", tableName),
+			},
+			BatchTickerDuration:         time.Millisecond * 100,
+			BatchSizeLimit:              10,
+			URLs:                        []string{Infra.ElasticsearchURL},
+			DisableDiscoverNodesOnStart: true,
+		},
+	}
+
+	connector, err := cdc.NewConnector(ctx, cfg, func(msg cdc.Message) []elasticsearch.Action {
+		return nil
+	})
+	require.NoError(t, err)
+	t.Cleanup(connector.Close)
+
+	return connector
+}

--- a/integration_test/lifecycle_test.go
+++ b/integration_test/lifecycle_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestConnector_WaitUntilReadyAfterClose(t *testing.T) {
 	ctx := context.Background()
-	connector := newLifecycleConnector(t, ctx, "cdc_slot_lifecycle_closed", "cdc_publication_lifecycle_closed", "users_lifecycle_closed")
+	connector := newLifecycleConnector(ctx, t, "cdc_slot_lifecycle_closed", "cdc_publication_lifecycle_closed", "users_lifecycle_closed")
 
 	go connector.Start(ctx)
 
@@ -42,7 +42,7 @@ func TestConnector_WaitUntilReadyAfterClose(t *testing.T) {
 
 func TestConnector_CloseIsIdempotent(t *testing.T) {
 	ctx := context.Background()
-	connector := newLifecycleConnector(t, ctx, "cdc_slot_lifecycle_idempotent", "cdc_publication_lifecycle_idempotent", "users_lifecycle_idempotent")
+	connector := newLifecycleConnector(ctx, t, "cdc_slot_lifecycle_idempotent", "cdc_publication_lifecycle_idempotent", "users_lifecycle_idempotent")
 
 	go connector.Start(ctx)
 
@@ -58,11 +58,11 @@ func TestConnector_CloseIsIdempotent(t *testing.T) {
 
 func TestConnector_CloseBeforeWaitUntilReadyDoesNotHang(t *testing.T) {
 	ctx := context.Background()
-	connector := newLifecycleConnector(t, ctx, "cdc_slot_lifecycle_early_close", "cdc_publication_lifecycle_early_close", "users_lifecycle_early_close")
+	connector := newLifecycleConnector(ctx, t, "cdc_slot_lifecycle_early_close", "cdc_publication_lifecycle_early_close", "users_lifecycle_early_close")
 
 	go connector.Start(ctx)
 
-	time.Sleep(100 * time.Millisecond)
+	waitForConnectorReady(ctx, t, connector)
 	connector.Close()
 
 	waitCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
@@ -73,15 +73,20 @@ func TestConnector_CloseBeforeWaitUntilReadyDoesNotHang(t *testing.T) {
 	elapsed := time.Since(started)
 
 	assert.Less(t, elapsed, 3500*time.Millisecond, "WaitUntilReady must not hang after Close")
-	if err != nil {
-		assert.True(t,
-			err.Error() == "connector closed" || waitCtx.Err() != nil,
-			"unexpected error: %v", err,
-		)
-	}
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "connector closed")
 }
 
-func newLifecycleConnector(t *testing.T, ctx context.Context, slotName, publicationName, tableName string) cdc.Connector {
+func waitForConnectorReady(ctx context.Context, t *testing.T, connector cdc.Connector) {
+	t.Helper()
+
+	readyCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	require.NoError(t, connector.WaitUntilReady(readyCtx))
+}
+
+func newLifecycleConnector(ctx context.Context, t *testing.T, slotName, publicationName, tableName string) cdc.Connector {
 	t.Helper()
 
 	db, err := sql.Open("postgres", fmt.Sprintf(
@@ -145,7 +150,7 @@ func newLifecycleConnector(t *testing.T, ctx context.Context, slotName, publicat
 		},
 	}
 
-	connector, err := cdc.NewConnector(ctx, cfg, func(msg cdc.Message) []elasticsearch.Action {
+	connector, err := cdc.NewConnector(ctx, cfg, func(_ cdc.Message) []elasticsearch.Action {
 		return nil
 	})
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary
- Fixes incorrect `isClosed` helper that drained `readyCh` and could hang `WaitUntilReady` after `Close`
- Introduces `closedCh` + `sync.Once` and `signalReady()` so ready signaling and shutdown are separated
- Adds integration tests for close-after-ready, idempotent close, and early-close no-hang behavior

Closes #33

## Test plan
- [x] Integration: `WaitUntilReady` after `Close` returns `connector closed`
- [x] Integration: `Close` twice does not panic
- [x] Integration: early `Close` does not hang `WaitUntilReady`
- [ ] CI integration workflow passes